### PR TITLE
Check update

### DIFF
--- a/server/src/main/java/com/omegaChess/board/ChessBoard.java
+++ b/server/src/main/java/com/omegaChess/board/ChessBoard.java
@@ -263,7 +263,7 @@ public class ChessBoard {
 
         // get the piece's legal moves
         System.out.println(piece);
-        LegalMoves listOfMoves = piece.legalMoves();
+        LegalMoves listOfMoves = piece.getNormalOrCheckMoves();
         ArrayList<String> validMoves = listOfMoves.getListOfMoves();
 
         boolean isEnPessant = listOfMoves.isEnPessant();

--- a/server/src/main/java/com/omegaChess/pieces/Bishop.java
+++ b/server/src/main/java/com/omegaChess/pieces/Bishop.java
@@ -193,4 +193,35 @@ public class Bishop extends ChessPiece {
 
         return new LegalMoves(validMoves, false, false);
     }
+
+    public LegalMoves checkingPieceMoves(String kingPos) {
+        int[] kPos = new int[2];
+        try {
+            kPos = board.parsePosition(kingPos);
+        } catch (IllegalPositionException e) {
+            e.printStackTrace();
+        }
+        int kr = kPos[0];
+        int kc = kPos[1];
+        int r = row;
+        int c = column;
+
+        int rIncrement = 1;
+        int cIncrement = 1;
+        if (r > kr) {rIncrement = -1;}
+        if (c > kc) {cIncrement = -1;}
+
+        ArrayList<String> validMoves = new ArrayList<>();
+        String pos = this.getPosition();
+        validMoves.add(pos);
+
+        while (r != (kr - rIncrement) && c != (kc - cIncrement)) {
+            r += rIncrement;
+            c += cIncrement;
+            pos = board.reverseParse(r, c);
+            validMoves.add(pos);
+        }
+
+        return new LegalMoves(validMoves, false, false);
+    }
 }

--- a/server/src/main/java/com/omegaChess/pieces/Bishop.java
+++ b/server/src/main/java/com/omegaChess/pieces/Bishop.java
@@ -194,7 +194,7 @@ public class Bishop extends ChessPiece {
         return new LegalMoves(validMoves, false, false);
     }
 
-    public LegalMoves checkingPieceMoves(String kingPos) {
+    public LegalMoves movesToBlockCheckingPiece(String kingPos) {
         int[] kPos = new int[2];
         try {
             kPos = board.parsePosition(kingPos);
@@ -208,11 +208,15 @@ public class Bishop extends ChessPiece {
 
         int rIncrement = 1;
         int cIncrement = 1;
-        if (r > kr) {rIncrement = -1;}
-        if (c > kc) {cIncrement = -1;}
+        if (r > kr) {
+            rIncrement = -1;
+        }
+        if (c > kc) {
+            cIncrement = -1;
+        }
 
-        ArrayList<String> validMoves = new ArrayList<>();
         String pos = this.getPosition();
+        ArrayList<String> validMoves = new ArrayList<>();
         validMoves.add(pos);
 
         while (r != (kr - rIncrement) && c != (kc - cIncrement)) {

--- a/server/src/main/java/com/omegaChess/pieces/Champion.java
+++ b/server/src/main/java/com/omegaChess/pieces/Champion.java
@@ -43,7 +43,7 @@ public class Champion extends ChessPiece{
         return new LegalMoves(moves, false, false);
     }
 
-    public LegalMoves checkingPieceMoves(String kingPos) {
+    public LegalMoves movesToBlockCheckingPiece(String kingPos) {
         int[] kPos = new int[2];
         try {
             kPos = board.parsePosition(kingPos);
@@ -59,6 +59,7 @@ public class Champion extends ChessPiece{
         String pos = this.getPosition();
         validMoves.add(pos);
 
+        //conditions to see if king is within the sliding move-set
         if (r < kr && c == kc) {
             while (r < (kr - 1)) {
                 r += 1;

--- a/server/src/main/java/com/omegaChess/pieces/Champion.java
+++ b/server/src/main/java/com/omegaChess/pieces/Champion.java
@@ -43,4 +43,51 @@ public class Champion extends ChessPiece{
         return new LegalMoves(moves, false, false);
     }
 
+    public LegalMoves checkingPieceMoves(String kingPos) {
+        int[] kPos = new int[2];
+        try {
+            kPos = board.parsePosition(kingPos);
+        } catch (IllegalPositionException e) {
+            e.printStackTrace();
+        }
+        int kr = kPos[0];
+        int kc = kPos[1];
+        int r = row;
+        int c = column;
+
+        ArrayList<String> validMoves = new ArrayList<>();
+        String pos = this.getPosition();
+        validMoves.add(pos);
+
+        if (r < kr && c == kc) {
+            while (r < (kr - 1)) {
+                r += 1;
+                pos = board.reverseParse(r, c);
+                validMoves.add(pos);
+            }
+        }
+        else if (r > kr && c == kc) {
+            while (r > (kr + 1)) {
+                r -= 1;
+                pos = board.reverseParse(r, c);
+                validMoves.add(pos);
+            }
+        }
+        else if (c < kc && r == kr) {
+            while (c < (kc - 1)) {
+                c += 1;
+                pos = board.reverseParse(r, c);
+                validMoves.add(pos);
+            }
+        }
+        else if (c > kc && r == kr) {
+            while (c > (kc + 1)) {
+                c -= 1;
+                pos = board.reverseParse(r, c);
+                validMoves.add(pos);
+            }
+        }
+
+        return new LegalMoves(validMoves, false, false);
+    }
 }

--- a/server/src/main/java/com/omegaChess/pieces/ChessPiece.java
+++ b/server/src/main/java/com/omegaChess/pieces/ChessPiece.java
@@ -65,7 +65,7 @@ public abstract class ChessPiece {
         return this.moved;
     }
 
-    private LegalMoves getNormalOrCheckMoves() {
+    public LegalMoves getNormalOrCheckMoves() {
         LegalMoves nonCheckLegal = this.legalMoves();
 
         if (!(this instanceof King)) {

--- a/server/src/main/java/com/omegaChess/pieces/ChessPiece.java
+++ b/server/src/main/java/com/omegaChess/pieces/ChessPiece.java
@@ -89,7 +89,7 @@ public abstract class ChessPiece {
             }
 
             if (myKing.isKingInCheck()) {
-                LegalMoves inCheckLegal = myKing.getCheckingPiece().checkingPieceMoves(myKing.getPosition());
+                LegalMoves inCheckLegal = myKing.getCheckingPiece().movesToBlockCheckingPiece(myKing.getPosition());
                 ArrayList<String> checkerLegal = inCheckLegal.getListOfMoves();
                 ArrayList<String> allLegal = nonCheckLegal.getListOfMoves();
                 ArrayList<String> legalMoves = new ArrayList<>();
@@ -119,6 +119,7 @@ public abstract class ChessPiece {
 
     /* To be implemented in concrete subclasses. Returns the list of possible locations that the
     * piece checking the king can be at in between itself and the king, including its current
-    * position. */
-    abstract public LegalMoves checkingPieceMoves(String kingPos);
+    * position. Assumed that kingPos is within piece's valid move-set, since only called after
+    * the king's isKingInCheck method. */
+    abstract public LegalMoves movesToBlockCheckingPiece(String kingPos);
 }

--- a/server/src/main/java/com/omegaChess/pieces/ChessPiece.java
+++ b/server/src/main/java/com/omegaChess/pieces/ChessPiece.java
@@ -3,6 +3,8 @@ package com.omegaChess.pieces;
 import com.omegaChess.board.ChessBoard;
 import com.omegaChess.exceptions.IllegalPositionException;
 
+import java.util.ArrayList;
+
 public abstract class ChessPiece {
     public enum Color {WHITE, BLACK}
 
@@ -63,6 +65,48 @@ public abstract class ChessPiece {
         return this.moved;
     }
 
+    private LegalMoves getNormalOrCheckMoves() {
+        LegalMoves nonCheckLegal = this.legalMoves();
+
+        if (!(this instanceof King)) {
+            King myKing = null;
+            if (this.color == Color.WHITE) {
+                ArrayList<ChessPiece> myPieces = this.board.get_white_pieces();
+                for (ChessPiece piece : myPieces) {
+                    if (piece instanceof King) {
+                        myKing = (King) piece;
+                        break;
+                    }
+                }
+            } else {
+                ArrayList<ChessPiece> myPieces = this.board.get_black_pieces();
+                for (ChessPiece piece : myPieces) {
+                    if (piece instanceof King) {
+                        myKing = (King) piece;
+                        break;
+                    }
+                }
+            }
+
+            if (myKing.isKingInCheck()) {
+                LegalMoves inCheckLegal = myKing.getCheckingPiece().checkingPieceMoves(myKing.getPosition());
+                ArrayList<String> checkerLegal = inCheckLegal.getListOfMoves();
+                ArrayList<String> allLegal = nonCheckLegal.getListOfMoves();
+                ArrayList<String> legalMoves = new ArrayList<>();
+
+                for (String al : allLegal) {
+                    if (checkerLegal.contains(al)) {
+                        legalMoves.add(al);
+                    }
+                }
+
+                return new LegalMoves(legalMoves, false, false);
+            }
+        }
+
+        return nonCheckLegal;
+    }
+
     /* To be implemented in the concrete subclasses. Returns a one-character piece corresponding
     * to the type of the piece. */
     abstract public String toString();
@@ -70,6 +114,11 @@ public abstract class ChessPiece {
     /* To be implemented in the concrete subclasses. Returns a list of all legal moves that
     * piece can make. Each string in the arraylist should be the position of a possible destination
     * for the piece. Order of legal moves is irrelevant. Return an empty list if no moves are
-    * available. Queen and Knight should return empty lists.*/
+    * available. */
     abstract public LegalMoves legalMoves();
+
+    /* To be implemented in concrete subclasses. Returns the list of possible locations that the
+    * piece checking the king can be at in between itself and the king, including its current
+    * position. */
+    abstract public LegalMoves checkingPieceMoves(String kingPos);
 }

--- a/server/src/main/java/com/omegaChess/pieces/InvalidSpace.java
+++ b/server/src/main/java/com/omegaChess/pieces/InvalidSpace.java
@@ -33,5 +33,5 @@ public class InvalidSpace extends ChessPiece{
     }
 
     @Override
-    public LegalMoves checkingPieceMoves(String kingPos) { return null; }
+    public LegalMoves movesToBlockCheckingPiece(String kingPos) { return null; }
 }

--- a/server/src/main/java/com/omegaChess/pieces/InvalidSpace.java
+++ b/server/src/main/java/com/omegaChess/pieces/InvalidSpace.java
@@ -31,4 +31,7 @@ public class InvalidSpace extends ChessPiece{
     public LegalMoves legalMoves() {
         return null;
     }
+
+    @Override
+    public LegalMoves checkingPieceMoves(String kingPos) { return null; }
 }

--- a/server/src/main/java/com/omegaChess/pieces/King.java
+++ b/server/src/main/java/com/omegaChess/pieces/King.java
@@ -336,7 +336,7 @@ public class King extends ChessPiece {
     }
 
     //The King will never use this function since the king can never check the other king
-    public LegalMoves checkingPieceMoves(String kingPos) {
+    public LegalMoves movesToBlockCheckingPiece(String kingPos) {
         return null;
     }
 }

--- a/server/src/main/java/com/omegaChess/pieces/King.java
+++ b/server/src/main/java/com/omegaChess/pieces/King.java
@@ -6,9 +6,15 @@ import com.omegaChess.exceptions.IllegalPositionException;
 import java.util.ArrayList;
 
 public class King extends ChessPiece {
+    private ChessPiece checkingPiece = null;
+
     public King(ChessBoard board, Color color) {
         super(board, color);
         // TODO Auto-generated constructor stub
+    }
+
+    public ChessPiece getCheckingPiece() {
+        return checkingPiece;
     }
 
     /*
@@ -61,7 +67,7 @@ public class King extends ChessPiece {
 
             // can't move to a friend piece or somewhere that puts in check
             if((tmp_piece == null || tmp_piece.getColor() != this.color) &&
-                    !is_king_in_check(tmp_str))
+                    !willKingBeInCheck(tmp_str))
             {
                 legalMoves.add(tmp_str);
             }
@@ -79,7 +85,7 @@ public class King extends ChessPiece {
 
             // can't move to a friend piece or somewhere that puts in check
             if((tmp_piece == null || tmp_piece.getColor() != this.color) &&
-                    !is_king_in_check(tmp_str))
+                    !willKingBeInCheck(tmp_str))
             {
                 legalMoves.add(tmp_str);
             }
@@ -97,7 +103,7 @@ public class King extends ChessPiece {
 
             // can't move to a friend piece or somewhere that puts in check
             if((tmp_piece == null || tmp_piece.getColor() != this.color) &&
-                    !is_king_in_check(tmp_str))
+                    !willKingBeInCheck(tmp_str))
             {
                 legalMoves.add(tmp_str);
             }
@@ -115,7 +121,7 @@ public class King extends ChessPiece {
 
             // can't move to a friend piece or somewhere that puts in check
             if((tmp_piece == null || tmp_piece.getColor() != this.color) &&
-                    !is_king_in_check(tmp_str))
+                    !willKingBeInCheck(tmp_str))
             {
                 legalMoves.add(tmp_str);
             }
@@ -133,7 +139,7 @@ public class King extends ChessPiece {
 
             // can't move to a friend piece or somewhere that puts in check
             if((tmp_piece == null || tmp_piece.getColor() != this.color) &&
-                    !is_king_in_check(tmp_str))
+                    !willKingBeInCheck(tmp_str))
             {
                 legalMoves.add(tmp_str);
             }
@@ -151,7 +157,7 @@ public class King extends ChessPiece {
 
             // can't move to a friend piece or somewhere that puts in check
             if((tmp_piece == null || tmp_piece.getColor() != this.color) &&
-                    !is_king_in_check(tmp_str))
+                    !willKingBeInCheck(tmp_str))
             {
                 legalMoves.add(tmp_str);
             }
@@ -169,7 +175,7 @@ public class King extends ChessPiece {
 
             // can't move to a friend piece or somewhere that puts in check
             if((tmp_piece == null || tmp_piece.getColor() != this.color) &&
-                    !is_king_in_check(tmp_str))
+                    !willKingBeInCheck(tmp_str))
             {
                 legalMoves.add(tmp_str);
             }
@@ -187,7 +193,7 @@ public class King extends ChessPiece {
 
             // can't move to a friend piece or somewhere that puts in check
             if((tmp_piece == null || tmp_piece.getColor() != this.color) &&
-                    !is_king_in_check(tmp_str))
+                    !willKingBeInCheck(tmp_str))
             {
                 legalMoves.add(tmp_str);
             }
@@ -215,7 +221,7 @@ public class King extends ChessPiece {
             // check if the castle is legal
             boolean okToCastle = rook instanceof Rook && !rook.isMoved(); //rook is there and hasn't moved
             okToCastle = okToCastle && bishop == null && knight == null; //bishop and knight spots are both empty
-            okToCastle = okToCastle && !is_king_in_check(bishop_str) && !is_king_in_check(knight_str); //king is not in check in either spot
+            okToCastle = okToCastle && !willKingBeInCheck(bishop_str) && !willKingBeInCheck(knight_str); //king is not in check in either spot
 
             // if legal, add move to list
             if(okToCastle) {
@@ -245,7 +251,7 @@ public class King extends ChessPiece {
             // check if the castle is legal
             okToCastle = rook instanceof Rook && !rook.isMoved(); //rook is there and hasn't moved
             okToCastle = okToCastle && queen == null && bishop == null && knight == null; //queen, bishop, and knight spots are all empty
-            okToCastle = okToCastle && !is_king_in_check(queen_str) && !is_king_in_check(bishop_str); //king is not in check in either spot
+            okToCastle = okToCastle && !willKingBeInCheck(queen_str) && !willKingBeInCheck(bishop_str); //king is not in check in either spot
 
             // if legal, add move to list
             if(okToCastle) {
@@ -257,7 +263,7 @@ public class King extends ChessPiece {
         return new LegalMoves(legalMoves, false, isCastle);
     }
 
-    public boolean is_king_in_check(String new_pos)
+    private boolean willKingBeInCheck(String new_pos)
     {
         ArrayList<ChessPiece> pieces;
         if( this.color == Color.BLACK )
@@ -305,5 +311,32 @@ public class King extends ChessPiece {
         }
 
         return false;
+    }
+
+    public boolean isKingInCheck() {
+        String myPos = this.getPosition();
+
+        ArrayList<ChessPiece> opponentPieces;
+        if (color == Color.WHITE) {
+            opponentPieces = board.get_black_pieces();
+        }
+        else {
+            opponentPieces = board.get_white_pieces();
+        }
+
+        for (ChessPiece piece : opponentPieces) {
+            if (!(piece instanceof King) && piece.legalMoves().getListOfMoves().contains(myPos)) {
+                checkingPiece = piece;
+                return true;
+            }
+        }
+
+        checkingPiece = null;
+        return false;
+    }
+
+    //The King will never use this function since the king can never check the other king
+    public LegalMoves checkingPieceMoves(String kingPos) {
+        return null;
     }
 }

--- a/server/src/main/java/com/omegaChess/pieces/Knight.java
+++ b/server/src/main/java/com/omegaChess/pieces/Knight.java
@@ -186,5 +186,11 @@ public class Knight extends ChessPiece {
 
         return new LegalMoves(legalMoves, false, false);
     }
+
+    public LegalMoves checkingPieceMoves(String kinPos) {
+        ArrayList<String> validMoves = new ArrayList<>();
+        validMoves.add(this.getPosition());
+        return new LegalMoves(validMoves, false, false);
+    }
 }
 

--- a/server/src/main/java/com/omegaChess/pieces/Knight.java
+++ b/server/src/main/java/com/omegaChess/pieces/Knight.java
@@ -187,7 +187,7 @@ public class Knight extends ChessPiece {
         return new LegalMoves(legalMoves, false, false);
     }
 
-    public LegalMoves checkingPieceMoves(String kinPos) {
+    public LegalMoves movesToBlockCheckingPiece(String kinPos) {
         ArrayList<String> validMoves = new ArrayList<>();
         validMoves.add(this.getPosition());
         return new LegalMoves(validMoves, false, false);

--- a/server/src/main/java/com/omegaChess/pieces/Pawn.java
+++ b/server/src/main/java/com/omegaChess/pieces/Pawn.java
@@ -130,7 +130,7 @@ public class Pawn extends ChessPiece {
         return moves;
     }
 
-    public LegalMoves checkingPieceMoves(String kinPos) {
+    public LegalMoves movesToBlockCheckingPiece(String kinPos) {
         ArrayList<String> validMoves = new ArrayList<>();
         validMoves.add(this.getPosition());
         return new LegalMoves(validMoves, false, false);

--- a/server/src/main/java/com/omegaChess/pieces/Pawn.java
+++ b/server/src/main/java/com/omegaChess/pieces/Pawn.java
@@ -130,5 +130,10 @@ public class Pawn extends ChessPiece {
         return moves;
     }
 
+    public LegalMoves checkingPieceMoves(String kinPos) {
+        ArrayList<String> validMoves = new ArrayList<>();
+        validMoves.add(this.getPosition());
+        return new LegalMoves(validMoves, false, false);
+    }
 }
 

--- a/server/src/main/java/com/omegaChess/pieces/Queen.java
+++ b/server/src/main/java/com/omegaChess/pieces/Queen.java
@@ -348,5 +348,43 @@ public class Queen extends ChessPiece {
         return validMoves;
     }
 
+    public LegalMoves checkingPieceMoves(String kingPos) {
+        int[] kPos = new int[2];
+        try {
+            kPos = board.parsePosition(kingPos);
+        } catch (IllegalPositionException e) {
+            e.printStackTrace();
+        }
+        int kr = kPos[0];
+        int kc = kPos[1];
+        int r = row;
+        int c = column;
+
+        int rIncrement = 0;
+        int cIncrement = 0;
+        if (r > kr) {
+            rIncrement = -1;
+        } else if (r < kr) {
+            rIncrement = 1;
+        }
+        if (c > kc) {
+            cIncrement = -1;
+        } else if (c < kc) {
+            cIncrement = 1;
+        }
+
+        ArrayList<String> validMoves = new ArrayList<>();
+        String pos = this.getPosition();
+        validMoves.add(pos);
+
+        while (r != (kr - rIncrement) && c != (kc - cIncrement)) {
+            r += rIncrement;
+            c += cIncrement;
+            pos = board.reverseParse(r, c);
+            validMoves.add(pos);
+        }
+
+        return new LegalMoves(validMoves, false, false);
+    }
 }
 

--- a/server/src/main/java/com/omegaChess/pieces/Queen.java
+++ b/server/src/main/java/com/omegaChess/pieces/Queen.java
@@ -348,7 +348,7 @@ public class Queen extends ChessPiece {
         return validMoves;
     }
 
-    public LegalMoves checkingPieceMoves(String kingPos) {
+    public LegalMoves movesToBlockCheckingPiece(String kingPos) {
         int[] kPos = new int[2];
         try {
             kPos = board.parsePosition(kingPos);
@@ -373,11 +373,11 @@ public class Queen extends ChessPiece {
             cIncrement = 1;
         }
 
-        ArrayList<String> validMoves = new ArrayList<>();
         String pos = this.getPosition();
+        ArrayList<String> validMoves = new ArrayList<>();
         validMoves.add(pos);
 
-        while (r != (kr - rIncrement) && c != (kc - cIncrement)) {
+        while (r != (kr - rIncrement) || c != (kc - cIncrement)) {
             r += rIncrement;
             c += cIncrement;
             pos = board.reverseParse(r, c);

--- a/server/src/main/java/com/omegaChess/pieces/Rook.java
+++ b/server/src/main/java/com/omegaChess/pieces/Rook.java
@@ -188,4 +188,43 @@ public class Rook extends ChessPiece {
 
         return new LegalMoves(validMoves, false, false);
     }
+
+    public LegalMoves checkingPieceMoves(String kingPos) {
+        int[] kPos = new int[2];
+        try {
+            kPos = board.parsePosition(kingPos);
+        } catch (IllegalPositionException e) {
+            e.printStackTrace();
+        }
+        int kr = kPos[0];
+        int kc = kPos[1];
+        int r = row;
+        int c = column;
+
+        int rIncrement = 0;
+        int cIncrement = 0;
+        if (r > kr) {
+            rIncrement = -1;
+        } else if (r < kr) {
+            rIncrement = 1;
+        }
+        if (c > kc) {
+            cIncrement = -1;
+        } else if (c < kc) {
+            cIncrement = 1;
+        }
+
+        ArrayList<String> validMoves = new ArrayList<>();
+        String pos = this.getPosition();
+        validMoves.add(pos);
+
+        while (r != (kr - rIncrement) && c != (kc - cIncrement)) {
+            r += rIncrement;
+            c += cIncrement;
+            pos = board.reverseParse(r, c);
+            validMoves.add(pos);
+        }
+
+        return new LegalMoves(validMoves, false, false);
+    }
 }

--- a/server/src/main/java/com/omegaChess/pieces/Rook.java
+++ b/server/src/main/java/com/omegaChess/pieces/Rook.java
@@ -189,7 +189,7 @@ public class Rook extends ChessPiece {
         return new LegalMoves(validMoves, false, false);
     }
 
-    public LegalMoves checkingPieceMoves(String kingPos) {
+    public LegalMoves movesToBlockCheckingPiece(String kingPos) {
         int[] kPos = new int[2];
         try {
             kPos = board.parsePosition(kingPos);
@@ -214,11 +214,11 @@ public class Rook extends ChessPiece {
             cIncrement = 1;
         }
 
-        ArrayList<String> validMoves = new ArrayList<>();
         String pos = this.getPosition();
+        ArrayList<String> validMoves = new ArrayList<>();
         validMoves.add(pos);
 
-        while (r != (kr - rIncrement) && c != (kc - cIncrement)) {
+        while (r != (kr - rIncrement) || c != (kc - cIncrement)) {
             r += rIncrement;
             c += cIncrement;
             pos = board.reverseParse(r, c);

--- a/server/src/main/java/com/omegaChess/pieces/Wizard.java
+++ b/server/src/main/java/com/omegaChess/pieces/Wizard.java
@@ -48,4 +48,9 @@ public class Wizard extends ChessPiece {
         return new LegalMoves(moves, false, false);
     }
 
+    public LegalMoves checkingPieceMoves(String kinPos) {
+        ArrayList<String> validMoves = new ArrayList<>();
+        validMoves.add(this.getPosition());
+        return new LegalMoves(validMoves, false, false);
+    }
 }

--- a/server/src/main/java/com/omegaChess/pieces/Wizard.java
+++ b/server/src/main/java/com/omegaChess/pieces/Wizard.java
@@ -48,7 +48,7 @@ public class Wizard extends ChessPiece {
         return new LegalMoves(moves, false, false);
     }
 
-    public LegalMoves checkingPieceMoves(String kinPos) {
+    public LegalMoves movesToBlockCheckingPiece(String kinPos) {
         ArrayList<String> validMoves = new ArrayList<>();
         validMoves.add(this.getPosition());
         return new LegalMoves(validMoves, false, false);

--- a/server/src/test/java/com/omegaChess/TestBishop.java
+++ b/server/src/test/java/com/omegaChess/TestBishop.java
@@ -95,4 +95,26 @@ class TestBishop {
 
         assertEquals(validMoves, bishopValid);
     }
+
+    @Test
+    public void testMovesToBlockCheckingPiece() {
+        ChessBoard board = new ChessBoard();
+        Bishop bishop = new Bishop(board, ChessPiece.Color.BLACK);
+        board.placePiece(bishop, "f5");
+        ArrayList<String> validMoves = new ArrayList<>();
+
+        validMoves.add("f5");
+        validMoves.add("g4");
+        validMoves.add("h3");
+        assertEquals(validMoves, bishop.movesToBlockCheckingPiece("i2").getListOfMoves());
+
+        validMoves.clear();
+        validMoves.add("f5");
+        validMoves.add("g6");
+        assertEquals(validMoves, bishop.movesToBlockCheckingPiece("h7").getListOfMoves());
+
+        validMoves.clear();
+        validMoves.add("f5");
+        assertEquals(validMoves, bishop.movesToBlockCheckingPiece("e6").getListOfMoves());
+    }
 }

--- a/server/src/test/java/com/omegaChess/TestChampion.java
+++ b/server/src/test/java/com/omegaChess/TestChampion.java
@@ -41,4 +41,29 @@ class TestChampion {
         ArrayList<String> actualMoves = moves.getListOfMoves();
         assertEquals(expectedMoves, actualMoves, "Expected moves not provided");
     }
+
+    @Test
+    public void testMovesToBlockCheckingPiece() {
+        ChessBoard board = new ChessBoard();
+        Champion champ = new Champion(board, ChessPiece.Color.WHITE);
+        board.placePiece(champ, "f5");
+        ArrayList<String> validMoves = new ArrayList<>();
+
+        validMoves.add("f5");
+        validMoves.add("f4");
+        assertEquals(validMoves, champ.movesToBlockCheckingPiece("f3").getListOfMoves());
+
+        validMoves.clear();
+        validMoves.add("f5");
+        validMoves.add("g5");
+        assertEquals(validMoves, champ.movesToBlockCheckingPiece("h5").getListOfMoves());
+
+        validMoves.clear();
+        validMoves.add("f5");
+        assertEquals(validMoves, champ.movesToBlockCheckingPiece("h3").getListOfMoves());
+
+        validMoves.clear();
+        validMoves.add("f5");
+        assertEquals(validMoves, champ.movesToBlockCheckingPiece("h7").getListOfMoves());
+    }
 }

--- a/server/src/test/java/com/omegaChess/TestChessBoard.java
+++ b/server/src/test/java/com/omegaChess/TestChessBoard.java
@@ -234,9 +234,11 @@ class TestChessBoard {
         ChessBoard board = new ChessBoard();
 
         Pawn whitePawn = new Pawn(board, ChessPiece.Color.WHITE);
+        King whiteKing = new King(board, ChessPiece.Color.WHITE);
 
-        // place black king at random spot on board
+        // place white pawn and king at random spot on board
         board.placePiece(whitePawn, "d3");
+        board.placePiece(whiteKing, "j2");
 
         try {
             board.move("d3", "d4");

--- a/server/src/test/java/com/omegaChess/TestChessPiece.java
+++ b/server/src/test/java/com/omegaChess/TestChessPiece.java
@@ -1,0 +1,65 @@
+package com.omegaChess;
+
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+
+import com.omegaChess.board.ChessBoard;
+import com.omegaChess.pieces.*;
+
+/* Test class for the getNormalOrCheckMoves chess piece method and any other methods that
+* can't be tested in an individual subclass. */
+public class TestChessPiece {
+    @Test
+    public void testGetMoves() {
+        ChessBoard board = new ChessBoard();
+        ArrayList<String> validMoves = new ArrayList<>();
+        King wKing = new King(board, ChessPiece.Color.WHITE);
+        Pawn wPawn = new Pawn(board, ChessPiece.Color.WHITE);
+        Pawn wPawn2 = new Pawn(board, ChessPiece.Color.WHITE);
+        Pawn wPawn3 = new Pawn(board, ChessPiece.Color.WHITE);
+        Pawn wPawn4 = new Pawn(board, ChessPiece.Color.WHITE);
+        Pawn wPawn5 = new Pawn(board, ChessPiece.Color.WHITE);
+        Bishop bBishop = new Bishop(board, ChessPiece.Color.BLACK);
+
+        //Not in check
+        board.placePiece(wKing, "g3");
+        board.placePiece(wPawn, "c2");
+
+        validMoves.add("c3");
+        validMoves.add("c4");
+        validMoves.add("c5");
+        assertEquals(validMoves, wPawn.getNormalOrCheckMoves().getListOfMoves());
+
+        //In Check, cannot capture/block
+        board.placePiece(bBishop, "c7");
+        board.placePiece(wPawn2, "d4");
+        wPawn2.setMoved(true);
+
+        validMoves.clear();
+        assertEquals(validMoves, wPawn.getNormalOrCheckMoves().getListOfMoves());
+        assertEquals(validMoves, wPawn2.getNormalOrCheckMoves().getListOfMoves());
+
+        //In Check, can block
+        board.placePiece(wPawn3, "f2");
+
+        validMoves.clear();
+        validMoves.add("f4");
+        assertEquals(validMoves, wPawn3.getNormalOrCheckMoves().getListOfMoves());
+
+        board.placePiece(wPawn4, "e4");
+        wPawn4.setMoved(true);
+
+        validMoves.clear();
+        validMoves.add("e5");
+        assertEquals(validMoves, wPawn4.getNormalOrCheckMoves().getListOfMoves());
+
+        //In Check, can capture
+        board.placePiece(wPawn5, "b6");
+
+        validMoves.clear();
+        validMoves.add("c7");
+        assertEquals(validMoves, wPawn5.getNormalOrCheckMoves().getListOfMoves());
+    }
+}

--- a/server/src/test/java/com/omegaChess/TestKing.java
+++ b/server/src/test/java/com/omegaChess/TestKing.java
@@ -10,12 +10,7 @@ import java.util.concurrent.BlockingDeque;
 import com.omegaChess.board.ChessBoard;
 import com.omegaChess.exceptions.IllegalMoveException;
 import com.omegaChess.exceptions.IllegalPositionException;
-import com.omegaChess.pieces.ChessPiece;
-import com.omegaChess.pieces.King;
-import com.omegaChess.pieces.Rook;
-import com.omegaChess.pieces.Queen;
-import com.omegaChess.pieces.Pawn;
-import com.omegaChess.pieces.LegalMoves;
+import com.omegaChess.pieces.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -282,4 +277,24 @@ class TestKing {
 
     }
 
+    @Test
+    public void testIsKingInCheck() {
+        ChessBoard board = new ChessBoard();
+        King king = new King(board, ChessPiece.Color.WHITE);
+        board.placePiece(king, "f1");
+        assertFalse(king.isKingInCheck());
+
+        Bishop bishop = new Bishop(board, ChessPiece.Color.WHITE);
+        board.placePiece(bishop, "d3");
+        assertFalse(king.isKingInCheck());
+
+        Rook rook = new Rook(board, ChessPiece.Color.BLACK);
+        board.placePiece(rook, "b1");
+        assertTrue(king.isKingInCheck());
+        assertTrue(king.getCheckingPiece() instanceof Rook);
+
+        board.placePiece(bishop, "b1");
+        assertFalse(king.isKingInCheck());
+        assertNull(king.getCheckingPiece());
+    }
 }

--- a/server/src/test/java/com/omegaChess/TestPawn.java
+++ b/server/src/test/java/com/omegaChess/TestPawn.java
@@ -293,9 +293,11 @@ class TestPawn {
         pawn = new Pawn(board, ChessPiece.Color.BLACK);
         pawn.setMoved(true);
         Pawn otherPawn = new Pawn(board, ChessPiece.Color.WHITE);
+        King king = new King(board, ChessPiece.Color.WHITE);
 
         board.placePiece(pawn, "d4");
         board.placePiece(otherPawn, "c2");
+        board.placePiece(king, "j2");
         try {
             board.move("c2", "c4");
         }
@@ -320,9 +322,11 @@ class TestPawn {
         pawn = new Pawn(board, ChessPiece.Color.BLACK);
         pawn.setMoved(true);
         otherPawn = new Pawn(board, ChessPiece.Color.WHITE);
+        king = new King(board, ChessPiece.Color.WHITE);
 
         board.placePiece(pawn, "b4");
         board.placePiece(otherPawn, "c2");
+        board.placePiece(king, "j2");
         try {
             board.move("c2", "c4");
         }
@@ -367,12 +371,16 @@ class TestPawn {
         pawn5.setMoved(true);
         Pawn pawn6 = new Pawn(board, ChessPiece.Color.WHITE);
         pawn6.setMoved(true);
+        King wKing = new King(board, ChessPiece.Color.WHITE);
+        King bKing = new King(board, ChessPiece.Color.BLACK);
         board.placePiece(pawn1, "e2");
         board.placePiece(pawn2, "f2");
         board.placePiece(pawn3, "g2");
         board.placePiece(pawn4, "e9");
         board.placePiece(pawn5, "f9");
         board.placePiece(pawn6, "g9");
+        board.placePiece(wKing, "j2");
+        board.placePiece(bKing, "j8");
         try {
             System.setIn(queenInput);
             board.move("e2", "e1");

--- a/server/src/test/java/com/omegaChess/TestQueen.java
+++ b/server/src/test/java/com/omegaChess/TestQueen.java
@@ -119,4 +119,32 @@ class TestQueen {
         assertEquals(validMoves, queenValid);
     }
 
+    @Test
+    public void testMovesToBlockCheckingPiece() {
+        ChessBoard board = new ChessBoard();
+        Queen queen = new Queen(board, ChessPiece.Color.WHITE);
+        board.placePiece(queen, "f5");
+        ArrayList<String> validMoves = new ArrayList<>();
+
+        validMoves.add("f5");
+        validMoves.add("f4");
+        validMoves.add("f3");
+        validMoves.add("f2");
+        assertEquals(validMoves, queen.movesToBlockCheckingPiece("f1").getListOfMoves());
+
+        validMoves.clear();
+        validMoves.add("f5");
+        validMoves.add("g4");
+        validMoves.add("h3");
+        assertEquals(validMoves, queen.movesToBlockCheckingPiece("i2").getListOfMoves());
+
+        validMoves.clear();
+        validMoves.add("f5");
+        validMoves.add("g5");
+        assertEquals(validMoves, queen.movesToBlockCheckingPiece("h5").getListOfMoves());
+
+        validMoves.clear();
+        validMoves.add("f5");
+        assertEquals(validMoves, queen.movesToBlockCheckingPiece("g6").getListOfMoves());
+    }
 }

--- a/server/src/test/java/com/omegaChess/TestRook.java
+++ b/server/src/test/java/com/omegaChess/TestRook.java
@@ -160,4 +160,25 @@ class TestRook {
         assertEquals(validMoves, rookValid);
     }
 
+    @Test
+    public void testMovesToBlockCheckingPiece() {
+        ChessBoard board = new ChessBoard();
+        Rook rook = new Rook(board, ChessPiece.Color.WHITE);
+        board.placePiece(rook, "f5");
+        ArrayList<String> validMoves = new ArrayList<>();
+
+        validMoves.add("f5");
+        validMoves.add("f4");
+        validMoves.add("f3");
+        assertEquals(validMoves, rook.movesToBlockCheckingPiece("f2").getListOfMoves());
+
+        validMoves.clear();
+        validMoves.add("f5");
+        validMoves.add("g5");
+        assertEquals(validMoves, rook.movesToBlockCheckingPiece("h5").getListOfMoves());
+
+        validMoves.clear();
+        validMoves.add("f5");
+        assertEquals(validMoves, rook.movesToBlockCheckingPiece("g6").getListOfMoves());
+    }
 }


### PR DESCRIPTION
I again modified numerous files to implement proper check state checking.

First, changed is_king_in_check to willKingBeInCheck to be used by the king when getting its moves and made a new isKingInCheck method for other pieces to check if their king is in check. Also made a variable to track which piece is putting the king in check.

Second, made method in ChessPiece to get check if a piece's king is in check and to either: get the normal legal moves if not in check, or get a filtered list based on the piece checking the king.

Third, made a new abstract function in ChessPiece that returns the end positions that will enable a piece to block or capture the checking piece. Will not be called by a King as kings can't check each other. Jumping pieces (Knight and Wizard) and the Pawn will only return its current position for capturing since they can't be blocked. Sliding pieces (Rook, Bishop, and Queen) will return all positions between itself and the king it's checking, including its current position. The Champion returns only its current position if the king is in a jump-reached position, or a list between itself and the king if the king is in a slid-reached position.

Finally, I changed the legal moves call in ChessBoard to call the new getNormalOrCheckMoves method described in my second change. This has cause the need for at least one king to be present in tests that use the move method.