### PR TITLE
Fixed King capturing in check bug

### DIFF
--- a/server/src/main/java/com/omegaChess/pieces/Bishop.java
+++ b/server/src/main/java/com/omegaChess/pieces/Bishop.java
@@ -44,7 +44,7 @@ public class Bishop extends ChessPiece {
      * moves in the ArrayList does not matter. If there are no legal moves, return
      * return an empty ArrayList, i.e., the size should be zero.
      */
-    public LegalMoves legalMoves(Boolean firstPass)
+    public LegalMoves legalMoves(Boolean firstPass, Boolean protectedPieceChecking)
     {
         ArrayList<String> validMoves = new ArrayList<>();
 
@@ -78,6 +78,12 @@ public class Bishop extends ChessPiece {
             }
             // if opponent piece - legal move but can't move in this direction anymore
             else if( tmp_piece.getColor() != this.color )
+            {
+                validMoves.add(tmp_str);
+                break;
+            }
+            // if same color piece, but king is checking protected piece - legal move but can't move in this direction anymore
+            else if( tmp_piece.getColor() == this.color && protectedPieceChecking)
             {
                 validMoves.add(tmp_str);
                 break;
@@ -118,6 +124,12 @@ public class Bishop extends ChessPiece {
                 validMoves.add(tmp_str);
                 break;
             }
+            // if same color piece, but king is checking protected piece - legal move but can't move in this direction anymore
+            else if( tmp_piece.getColor() == this.color && protectedPieceChecking)
+            {
+                validMoves.add(tmp_str);
+                break;
+            }
             // if same color piece - can't move here or in this direction anymore
             else if( tmp_piece.getColor() == this.color )
             {
@@ -150,6 +162,12 @@ public class Bishop extends ChessPiece {
             }
             // if opponent piece - legal move but can't move in this direction anymore
             else if( tmp_piece.getColor() != this.color )
+            {
+                validMoves.add(tmp_str);
+                break;
+            }
+            // if same color piece, but king is checking protected piece - legal move but can't move in this direction anymore
+            else if( tmp_piece.getColor() == this.color && protectedPieceChecking)
             {
                 validMoves.add(tmp_str);
                 break;
@@ -187,6 +205,12 @@ public class Bishop extends ChessPiece {
             }
             // if opponent piece - legal move but can't move in this direction anymore
             else if( tmp_piece.getColor() != this.color )
+            {
+                validMoves.add(tmp_str);
+                break;
+            }
+            // if same color piece, but king is checking protected piece - legal move but can't move in this direction anymore
+            else if( tmp_piece.getColor() == this.color && protectedPieceChecking)
             {
                 validMoves.add(tmp_str);
                 break;

--- a/server/src/main/java/com/omegaChess/pieces/Champion.java
+++ b/server/src/main/java/com/omegaChess/pieces/Champion.java
@@ -22,7 +22,7 @@ public class Champion extends ChessPiece{
     }
 
     @Override
-    public LegalMoves legalMoves(Boolean firstPass){
+    public LegalMoves legalMoves(Boolean firstPass, Boolean protectedPieceChecking){
         ArrayList<String> moves = new ArrayList<>();
 
         //check if leaving position puts own king in check on first call
@@ -43,7 +43,8 @@ public class Champion extends ChessPiece{
                 e.printStackTrace();
             }
             if (((piece != null && piece.getColor() != this.color)
-                    && !(piece instanceof InvalidSpace)) || piece == null)
+                    && !(piece instanceof InvalidSpace)) || piece == null
+                    || (piece != null && !(piece instanceof InvalidSpace) && piece.getColor() == this.color && protectedPieceChecking))
                 moves.add(loc);
         } for (int i = 1; i <= 2; i++){
             ChessPiece piece = null;
@@ -56,7 +57,9 @@ public class Champion extends ChessPiece{
                 e.printStackTrace();
             }
             if (((piece != null && piece.getColor() != this.color)
-                    && !(piece instanceof InvalidSpace)) || piece == null)
+                    && !(piece instanceof InvalidSpace)) || piece == null
+                    || (piece != null && !(piece instanceof InvalidSpace)
+                    && piece.getColor() == this.color && protectedPieceChecking))
                 moves.add(loc);
         } for (int i = 1; i <= 2; i++){
             ChessPiece piece = null;
@@ -69,7 +72,9 @@ public class Champion extends ChessPiece{
                 e.printStackTrace();
             }
             if (((piece != null && piece.getColor() != this.color)
-                    && !(piece instanceof InvalidSpace)) || piece == null)
+                    && !(piece instanceof InvalidSpace)) || piece == null
+                    || (piece != null && !(piece instanceof InvalidSpace)
+                    && piece.getColor() == this.color && protectedPieceChecking))
                 moves.add(loc);
         } for (int i = 1; i <= 2; i++){
             ChessPiece piece = null;
@@ -82,7 +87,9 @@ public class Champion extends ChessPiece{
                 e.printStackTrace();
             }
             if (((piece != null && piece.getColor() != this.color)
-                    && !(piece instanceof InvalidSpace)) || piece == null)
+                    && !(piece instanceof InvalidSpace)) || piece == null
+                    || (piece != null && !(piece instanceof InvalidSpace)
+                    && piece.getColor() == this.color && protectedPieceChecking))
                 moves.add(loc);
         }
         ArrayList<String>  diagStr = new ArrayList<>();
@@ -120,7 +127,9 @@ public class Champion extends ChessPiece{
         for (int i = 0; i < diags.size(); i++){
             ChessPiece piece = diags.get(i);
             if (((piece != null && piece.getColor() != this.color)
-                    && !(piece instanceof InvalidSpace)) || piece == null)
+                    && !(piece instanceof InvalidSpace)) || piece == null
+                    || (piece != null && !(piece instanceof InvalidSpace)
+                    && piece.getColor() == this.color && protectedPieceChecking))
                 moves.add(diagStr.get(i));
         }
         return new LegalMoves(moves, false, false);

--- a/server/src/main/java/com/omegaChess/pieces/ChessPiece.java
+++ b/server/src/main/java/com/omegaChess/pieces/ChessPiece.java
@@ -91,7 +91,7 @@ public abstract class ChessPiece {
             if (myKing.isKingInCheck()) {
                 LegalMoves inCheckLegal = myKing.getCheckingPiece().movesToBlockCheckingPiece(myKing.getPosition());
                 ArrayList<String> checkerLegal = inCheckLegal.getListOfMoves();
-                ArrayList<String> allLegal = this.legalMoves(false).getListOfMoves();
+                ArrayList<String> allLegal = this.legalMoves(false, false).getListOfMoves();
                 ArrayList<String> legalMoves = new ArrayList<>();
 
                 for (String al : allLegal) {
@@ -103,11 +103,11 @@ public abstract class ChessPiece {
                 return new LegalMoves(legalMoves, false, false);
             }
             else {
-                return this.legalMoves(true);
+                return this.legalMoves(true, false);
             }
         }
 
-        return this.legalMoves(true);
+        return this.legalMoves(true, false);
     }
 
     public King getMyKing() {
@@ -151,7 +151,7 @@ public abstract class ChessPiece {
     * piece can make. Each string in the arraylist should be the position of a possible destination
     * for the piece. Order of legal moves is irrelevant. Return an empty list if no moves are
     * available. */
-    abstract public LegalMoves legalMoves(Boolean firstPass);
+    abstract public LegalMoves legalMoves(Boolean firstPass, Boolean protectedPieceChecking);
 
     /* To be implemented in concrete subclasses. Returns the list of possible locations that the
     * piece checking the king can be at in between itself and the king, including its current

--- a/server/src/main/java/com/omegaChess/pieces/InvalidSpace.java
+++ b/server/src/main/java/com/omegaChess/pieces/InvalidSpace.java
@@ -16,7 +16,7 @@ public class InvalidSpace extends ChessPiece{
     }
 
     @Override
-    public LegalMoves legalMoves(Boolean firstPass) {
+    public LegalMoves legalMoves(Boolean firstPass, Boolean protectedPieceChecking) {
         return null;
     }
 

--- a/server/src/main/java/com/omegaChess/pieces/King.java
+++ b/server/src/main/java/com/omegaChess/pieces/King.java
@@ -51,7 +51,7 @@ public class King extends ChessPiece {
      * moves in the ArrayList does not matter. If there are no legal moves, return
      * return an empty ArrayList, i.e., the size should be zero.
      */
-    public LegalMoves legalMoves(Boolean firstPass)
+    public LegalMoves legalMoves(Boolean firstPass, Boolean protectedPieceChecking)
     {
         ArrayList<String> legalMoves = new ArrayList<>();
         boolean isCastle = false;
@@ -293,7 +293,7 @@ public class King extends ChessPiece {
                 if (new_pos.equals(diagLeft) || new_pos.equals(diagRight))
                     return true;
             // new_pos is somewhere a white piece can move, return true that king is in check
-            }else if (!(piece instanceof King) && piece.legalMoves(false).getListOfMoves().contains(new_pos)) {
+            }else if (!(piece instanceof King) && piece.legalMoves(false, true).getListOfMoves().contains(new_pos)) {
                 return true;
             }
             // handle king separately otherwise recursion and stackoverflow error occurs
@@ -340,7 +340,7 @@ public class King extends ChessPiece {
         }
 
         for (ChessPiece piece : opponentPieces) {
-            if (!(piece instanceof King) && piece.legalMoves(false).getListOfMoves().contains(myPos)) {
+            if (!(piece instanceof King) && piece.legalMoves(false, false).getListOfMoves().contains(myPos)) {
                 checkingPiece = piece;
                 return true;
             }

--- a/server/src/main/java/com/omegaChess/pieces/Knight.java
+++ b/server/src/main/java/com/omegaChess/pieces/Knight.java
@@ -46,7 +46,7 @@ public class Knight extends ChessPiece {
      * moves in the ArrayList does not matter. If there are no legal moves, return
      * return an empty ArrayList, i.e., the size should be zero.
      */
-    public LegalMoves legalMoves(Boolean firstPass)
+    public LegalMoves legalMoves(Boolean firstPass, Boolean protectedPieceChecking)
     {
         ArrayList<String> legalMoves = new ArrayList<>();
 
@@ -88,7 +88,7 @@ public class Knight extends ChessPiece {
             }
 
             // can't move to a friend piece
-            if(tmp_piece == null || (tmp_piece != null && tmp_piece.getColor() != this.color))
+            if(tmp_piece == null || (tmp_piece != null && tmp_piece.getColor() != this.color) || (tmp_piece != null && tmp_piece.getColor() == this.color && protectedPieceChecking))
             {
                 legalMoves.add(tmp_str);
             }
@@ -105,7 +105,7 @@ public class Knight extends ChessPiece {
             }
 
             // can't move to a friend piece
-            if(tmp_piece == null || (tmp_piece != null && tmp_piece.getColor() != this.color))
+            if(tmp_piece == null || (tmp_piece != null && tmp_piece.getColor() != this.color) || (tmp_piece != null && tmp_piece.getColor() == this.color && protectedPieceChecking))
             {
                 legalMoves.add(tmp_str);
             }
@@ -122,7 +122,7 @@ public class Knight extends ChessPiece {
             }
 
             // can't move to a friend piece
-            if(tmp_piece == null || (tmp_piece != null && tmp_piece.getColor() != this.color))
+            if(tmp_piece == null || (tmp_piece != null && tmp_piece.getColor() != this.color) || (tmp_piece != null && tmp_piece.getColor() == this.color && protectedPieceChecking))
             {
                 legalMoves.add(tmp_str);
             }
@@ -139,7 +139,7 @@ public class Knight extends ChessPiece {
             }
 
             // can't move to a friend piece
-            if(tmp_piece == null || (tmp_piece != null && tmp_piece.getColor() != this.color))
+            if(tmp_piece == null || (tmp_piece != null && tmp_piece.getColor() != this.color) || (tmp_piece != null && tmp_piece.getColor() == this.color && protectedPieceChecking))
             {
                 legalMoves.add(tmp_str);
             }
@@ -156,7 +156,7 @@ public class Knight extends ChessPiece {
             }
 
             // can't move to a friend piece
-            if(tmp_piece == null || (tmp_piece != null && tmp_piece.getColor() != this.color))
+            if(tmp_piece == null || (tmp_piece != null && tmp_piece.getColor() != this.color) || (tmp_piece != null && tmp_piece.getColor() == this.color && protectedPieceChecking))
             {
                 legalMoves.add(tmp_str);
             }
@@ -173,7 +173,7 @@ public class Knight extends ChessPiece {
             }
 
             // can't move to a friend piece
-            if(tmp_piece == null || (tmp_piece != null && tmp_piece.getColor() != this.color))
+            if(tmp_piece == null || (tmp_piece != null && tmp_piece.getColor() != this.color) || (tmp_piece != null && tmp_piece.getColor() == this.color && protectedPieceChecking))
             {
                 legalMoves.add(tmp_str);
             }
@@ -190,7 +190,7 @@ public class Knight extends ChessPiece {
             }
 
             // can't move to a friend piece
-            if(tmp_piece == null || (tmp_piece != null && tmp_piece.getColor() != this.color))
+            if(tmp_piece == null || (tmp_piece != null && tmp_piece.getColor() != this.color) || (tmp_piece != null && tmp_piece.getColor() == this.color && protectedPieceChecking))
             {
                 legalMoves.add(tmp_str);
             }

--- a/server/src/main/java/com/omegaChess/pieces/Pawn.java
+++ b/server/src/main/java/com/omegaChess/pieces/Pawn.java
@@ -45,7 +45,7 @@ public class Pawn extends ChessPiece {
      * moves in the ArrayList does not matter. If there are no legal moves, return
      * return an empty ArrayList, i.e., the size should be zero.
      */
-    public LegalMoves legalMoves(Boolean firstPass)
+    public LegalMoves legalMoves(Boolean firstPass, Boolean protectedPieceChecking)
     {
         ArrayList<String> validMoves = new ArrayList<>();
 

--- a/server/src/main/java/com/omegaChess/pieces/Queen.java
+++ b/server/src/main/java/com/omegaChess/pieces/Queen.java
@@ -46,7 +46,7 @@ public class Queen extends ChessPiece {
      * moves in the ArrayList does not matter. If there are no legal moves, return
      * return an empty ArrayList, i.e., the size should be zero.
      */
-    public LegalMoves legalMoves(Boolean firstPass)
+    public LegalMoves legalMoves(Boolean firstPass, Boolean protectedPieceChecking)
     {
         ArrayList<String> validMoves = new ArrayList<>();
 
@@ -58,13 +58,13 @@ public class Queen extends ChessPiece {
         }
 
         // Queen moves are combination of bishop and rook
-        validMoves = rookMoves();
-        validMoves.addAll(bishopMoves());
+        validMoves = rookMoves(protectedPieceChecking);
+        validMoves.addAll(bishopMoves(protectedPieceChecking));
 
         return new LegalMoves(validMoves, false, false);
     }
 
-    public ArrayList<String> rookMoves()
+    public ArrayList<String> rookMoves(Boolean protectedPieceChecking)
     {
         ArrayList<String> validMoves = new ArrayList<>();
         // handle forward vertical pieces
@@ -87,6 +87,12 @@ public class Queen extends ChessPiece {
             }
             // if opponent piece - legal move but can't move in this direction anymore
             else if( tmp_piece.getColor() != this.color )
+            {
+                validMoves.add(tmp_str);
+                break;
+            }
+            // if same color piece, but king is checking protected piece - legal move but can't move in this direction anymore
+            else if( tmp_piece.getColor() == this.color && protectedPieceChecking)
             {
                 validMoves.add(tmp_str);
                 break;
@@ -125,6 +131,12 @@ public class Queen extends ChessPiece {
                 validMoves.add(tmp_str);
                 break;
             }
+            // if same color piece, but king is checking protected piece - legal move but can't move in this direction anymore
+            else if( tmp_piece.getColor() == this.color && protectedPieceChecking)
+            {
+                validMoves.add(tmp_str);
+                break;
+            }
             // if same color piece - can't move here or in this direction anymore
             else if( tmp_piece.getColor() == this.color )
             {
@@ -155,6 +167,12 @@ public class Queen extends ChessPiece {
             }
             // if opponent piece - legal move but can't move in this direction anymore
             else if( tmp_piece.getColor() != this.color )
+            {
+                validMoves.add(tmp_str);
+                break;
+            }
+            // if same color piece, but king is checking protected piece - legal move but can't move in this direction anymore
+            else if( tmp_piece.getColor() == this.color && protectedPieceChecking)
             {
                 validMoves.add(tmp_str);
                 break;
@@ -194,6 +212,12 @@ public class Queen extends ChessPiece {
                 validMoves.add(tmp_str);
                 break;
             }
+            // if same color piece, but king is checking protected piece - legal move but can't move in this direction anymore
+            else if( tmp_piece.getColor() == this.color && protectedPieceChecking)
+            {
+                validMoves.add(tmp_str);
+                break;
+            }
             // if same color piece - can't move here or in this direction anymore
             else if( tmp_piece.getColor() == this.color )
             {
@@ -208,7 +232,7 @@ public class Queen extends ChessPiece {
         return validMoves;
     }
 
-    public ArrayList<String> bishopMoves()
+    public ArrayList<String> bishopMoves(Boolean protectedPieceChecking)
     {
         ArrayList<String> validMoves = new ArrayList<>();
 
@@ -233,6 +257,12 @@ public class Queen extends ChessPiece {
             }
             // if opponent piece - legal move but can't move in this direction anymore
             else if( tmp_piece.getColor() != this.color )
+            {
+                validMoves.add(tmp_str);
+                break;
+            }
+            // if same color piece, but king is checking protected piece - legal move but can't move in this direction anymore
+            else if( tmp_piece.getColor() == this.color && protectedPieceChecking)
             {
                 validMoves.add(tmp_str);
                 break;
@@ -273,6 +303,12 @@ public class Queen extends ChessPiece {
                 validMoves.add(tmp_str);
                 break;
             }
+            // if same color piece, but king is checking protected piece - legal move but can't move in this direction anymore
+            else if( tmp_piece.getColor() == this.color && protectedPieceChecking)
+            {
+                validMoves.add(tmp_str);
+                break;
+            }
             // if same color piece - can't move here or in this direction anymore
             else if( tmp_piece.getColor() == this.color )
             {
@@ -305,6 +341,12 @@ public class Queen extends ChessPiece {
             }
             // if opponent piece - legal move but can't move in this direction anymore
             else if( tmp_piece.getColor() != this.color )
+            {
+                validMoves.add(tmp_str);
+                break;
+            }
+            // if same color piece, but king is checking protected piece - legal move but can't move in this direction anymore
+            else if( tmp_piece.getColor() == this.color && protectedPieceChecking)
             {
                 validMoves.add(tmp_str);
                 break;
@@ -342,6 +384,12 @@ public class Queen extends ChessPiece {
             }
             // if opponent piece - legal move but can't move in this direction anymore
             else if( tmp_piece.getColor() != this.color )
+            {
+                validMoves.add(tmp_str);
+                break;
+            }
+            // if same color piece, but king is checking protected piece - legal move but can't move in this direction anymore
+            else if( tmp_piece.getColor() == this.color && protectedPieceChecking)
             {
                 validMoves.add(tmp_str);
                 break;

--- a/server/src/main/java/com/omegaChess/pieces/Rook.java
+++ b/server/src/main/java/com/omegaChess/pieces/Rook.java
@@ -46,7 +46,7 @@ public class Rook extends ChessPiece {
      * moves in the ArrayList does not matter. If there are no legal moves, return
      * return an empty ArrayList, i.e., the size should be zero.
      */
-    public LegalMoves legalMoves(Boolean firstPass)
+    public LegalMoves legalMoves(Boolean firstPass, Boolean protectedPieceChecking)
     {
         ArrayList<String> validMoves = new ArrayList<>();
 
@@ -80,6 +80,12 @@ public class Rook extends ChessPiece {
             }
             // if opponent piece - legal move but can't move in this direction anymore
             else if( tmp_piece.getColor() != this.color )
+            {
+                validMoves.add(tmp_str);
+                break;
+            }
+            // if same color piece, but king is checking protected piece - legal move but can't move in this direction anymore
+            else if( tmp_piece.getColor() == this.color && protectedPieceChecking)
             {
                 validMoves.add(tmp_str);
                 break;
@@ -118,6 +124,12 @@ public class Rook extends ChessPiece {
                 validMoves.add(tmp_str);
                 break;
             }
+            // if same color piece, but king is checking protected piece - legal move but can't move in this direction anymore
+            else if( tmp_piece.getColor() == this.color && protectedPieceChecking)
+            {
+                validMoves.add(tmp_str);
+                break;
+            }
             // if same color piece - can't move here or in this direction anymore
             else if( tmp_piece.getColor() == this.color )
             {
@@ -148,6 +160,12 @@ public class Rook extends ChessPiece {
             }
             // if opponent piece - legal move but can't move in this direction anymore
             else if( tmp_piece.getColor() != this.color )
+            {
+                validMoves.add(tmp_str);
+                break;
+            }
+            // if same color piece, but king is checking protected piece - legal move but can't move in this direction anymore
+            else if( tmp_piece.getColor() == this.color && protectedPieceChecking)
             {
                 validMoves.add(tmp_str);
                 break;
@@ -183,6 +201,12 @@ public class Rook extends ChessPiece {
             }
             // if opponent piece - legal move but can't move in this direction anymore
             else if( tmp_piece.getColor() != this.color )
+            {
+                validMoves.add(tmp_str);
+                break;
+            }
+            // if same color piece, but king is checking protected piece - legal move but can't move in this direction anymore
+            else if( tmp_piece.getColor() == this.color && protectedPieceChecking)
             {
                 validMoves.add(tmp_str);
                 break;

--- a/server/src/main/java/com/omegaChess/pieces/Wizard.java
+++ b/server/src/main/java/com/omegaChess/pieces/Wizard.java
@@ -22,7 +22,7 @@ public class Wizard extends ChessPiece {
     }
 
     @Override
-    public LegalMoves legalMoves(Boolean firstPass){
+    public LegalMoves legalMoves(Boolean firstPass, Boolean protectedPieceChecking){
         ArrayList<String> moves = new ArrayList<>();
 
         //check if leaving position puts own king in check on first call
@@ -44,7 +44,9 @@ public class Wizard extends ChessPiece {
                 e.printStackTrace();
             }
             if (((piece != null && piece.getColor() != this.color)
-                    && !(piece instanceof InvalidSpace)) || piece == null)
+                    && !(piece instanceof InvalidSpace)) || piece == null
+                    || (piece != null && !(piece instanceof InvalidSpace)
+                    && piece.getColor() == this.color && protectedPieceChecking))
                 moves.add(loc);
         } for(int i = 1; i <= 3; i++){
             if (i == 2) continue;
@@ -58,7 +60,9 @@ public class Wizard extends ChessPiece {
                 e.printStackTrace();
             }
             if (((piece != null && piece.getColor() != this.color)
-                    && !(piece instanceof InvalidSpace)) || piece == null)
+                    && !(piece instanceof InvalidSpace)) || piece == null
+                    || (piece != null && !(piece instanceof InvalidSpace)
+                    && piece.getColor() == this.color && protectedPieceChecking))
                 moves.add(loc);
         } for(int i = 1; i <= 3; i++){
             if (i == 2) continue;
@@ -72,7 +76,9 @@ public class Wizard extends ChessPiece {
                 e.printStackTrace();
             }
             if (((piece != null && piece.getColor() != this.color)
-                    && !(piece instanceof InvalidSpace)) || piece == null)
+                    && !(piece instanceof InvalidSpace)) || piece == null
+                    || (piece != null && !(piece instanceof InvalidSpace)
+                    && piece.getColor() == this.color && protectedPieceChecking))
                 moves.add(loc);
         } for(int i = 1; i <= 3; i++){
             if (i == 2) continue;
@@ -86,7 +92,9 @@ public class Wizard extends ChessPiece {
                 e.printStackTrace();
             }
             if (((piece != null && piece.getColor() != this.color)
-                    && !(piece instanceof InvalidSpace)) || piece == null)
+                    && !(piece instanceof InvalidSpace)) || piece == null
+                    || (piece != null && !(piece instanceof InvalidSpace)
+                    && piece.getColor() == this.color && protectedPieceChecking))
                 moves.add(loc);
         }
         ArrayList<String> diagStr = new ArrayList<>();
@@ -124,7 +132,9 @@ public class Wizard extends ChessPiece {
         for (int i = 0; i < diags.size(); i++){
             ChessPiece piece = diags.get(i);
             if (((piece != null && piece.getColor() != this.color)
-                    && !(piece instanceof InvalidSpace)) || piece == null)
+                    && !(piece instanceof InvalidSpace)) || piece == null
+                    || (piece != null && !(piece instanceof InvalidSpace)
+                    && piece.getColor() == this.color && protectedPieceChecking))
                 moves.add(diagStr.get(i));
         }
         return new LegalMoves(moves, false, false);

--- a/server/src/test/java/com/omegaChess/TestBishop.java
+++ b/server/src/test/java/com/omegaChess/TestBishop.java
@@ -91,7 +91,7 @@ class TestBishop {
         validMoves.add("b6");
         validMoves.add("a7");
 
-        LegalMoves moves = bishop.legalMoves(true);
+        LegalMoves moves = bishop.legalMoves(true, false);
         ArrayList<String> bishopValid = moves.getListOfMoves();
         Collections.sort(validMoves);
         Collections.sort(bishopValid);

--- a/server/src/test/java/com/omegaChess/TestChampion.java
+++ b/server/src/test/java/com/omegaChess/TestChampion.java
@@ -40,7 +40,7 @@ class TestChampion {
         expectedMoves.add("c8"); expectedMoves.add("c9"); expectedMoves.add("c6"); expectedMoves.add("c5");
         expectedMoves.add("d7"); expectedMoves.add("e7"); expectedMoves.add("b7"); expectedMoves.add("a7");
         expectedMoves.add("a9"); expectedMoves.add("e9"); expectedMoves.add("e5"); expectedMoves.add("a5");
-        LegalMoves moves = champ.legalMoves(true);
+        LegalMoves moves = champ.legalMoves(true, false);
         ArrayList<String> actualMoves = moves.getListOfMoves();
         assertEquals(expectedMoves, actualMoves, "Expected moves not provided");
     }

--- a/server/src/test/java/com/omegaChess/TestKing.java
+++ b/server/src/test/java/com/omegaChess/TestKing.java
@@ -260,6 +260,26 @@ class TestKing {
 
         kingValid = king.legalMoves(true, false).getListOfMoves();
         assertEquals(validMoves, kingValid);
+
+        // test capture into check
+        board = new ChessBoard();
+        validMoves.clear();
+        king = new King(board, ChessPiece.Color.WHITE);
+        Pawn wPawn = new Pawn(board, ChessPiece.Color.WHITE);
+        Pawn wPawn2 = new Pawn(board, ChessPiece.Color.WHITE);
+        bKing = new King(board, ChessPiece.Color.BLACK);
+        bPawn = new Pawn(board, ChessPiece.Color.BLACK);
+        bRook = new Rook(board, ChessPiece.Color.BLACK);
+
+        board.placePiece(king, "f1");
+        board.placePiece(wPawn, "e2");
+        board.placePiece(wPawn2, "g2");
+        board.placePiece(bKing, "f10");
+        board.placePiece(bPawn, "f2");
+        board.placePiece(bRook, "f6");
+
+        kingValid = king.legalMoves(true, false).getListOfMoves();
+        assertEquals(validMoves, kingValid);
     }
 
     @Test

--- a/server/src/test/java/com/omegaChess/TestKing.java
+++ b/server/src/test/java/com/omegaChess/TestKing.java
@@ -9,7 +9,6 @@ import com.omegaChess.board.ChessBoard;
 import com.omegaChess.exceptions.IllegalMoveException;
 import com.omegaChess.exceptions.IllegalPositionException;
 import com.omegaChess.pieces.*;
-import com.omegaChess.server.TurnTracker;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -81,7 +80,7 @@ class TestKing {
         validMoves.add("f1");
 
         // get kings valid moves
-        LegalMoves moves = king.legalMoves(true);
+        LegalMoves moves = king.legalMoves(true, false);
         ArrayList<String> kingValid = moves.getListOfMoves();
 
         // Sort in case they come in a different order
@@ -107,7 +106,7 @@ class TestKing {
         validMoves.add("c4");
 
         // get kings valid moves
-        moves = king.legalMoves(true);
+        moves = king.legalMoves(true, false);
         kingValid = moves.getListOfMoves();
 
         // Sort in case they come in a different order
@@ -154,12 +153,112 @@ class TestKing {
 
         // get kings valid moves
         assert king1 != null;
-        kingValid = king1.legalMoves(true).getListOfMoves();
+        kingValid = king1.legalMoves(true, false).getListOfMoves();
 
         // Sort in case they come in a different order
         Collections.sort(validMoves);
         Collections.sort(kingValid);
 
+        assertEquals(validMoves, kingValid);
+
+        // test in check, can only capture to leave check, and checking piece is protected
+        board = new ChessBoard();
+        validMoves.clear();
+        king = new King(board, ChessPiece.Color.WHITE);
+        King bKing = new King(board, ChessPiece.Color.BLACK);
+        Queen bQueen = new Queen(board, ChessPiece.Color.BLACK);
+        Rook bRook = new Rook(board, ChessPiece.Color.BLACK);
+
+        board.placePiece(king, "f1");
+        board.placePiece(bKing, "f10");
+        board.placePiece(bQueen, "f2");
+        board.placePiece(bRook, "f6");
+
+        kingValid = king.legalMoves(true, false).getListOfMoves();
+        assertEquals(validMoves, kingValid);
+
+        board = new ChessBoard();
+        king = new King(board, ChessPiece.Color.WHITE);
+        bKing = new King(board, ChessPiece.Color.BLACK);
+        bQueen = new Queen(board, ChessPiece.Color.BLACK);
+        Bishop bBishop = new Bishop(board, ChessPiece.Color.BLACK);
+
+        board.placePiece(king, "f1");
+        board.placePiece(bKing, "f10");
+        board.placePiece(bQueen, "f2");
+        board.placePiece(bBishop, "h4");
+
+        kingValid = king.legalMoves(true, false).getListOfMoves();
+        assertEquals(validMoves, kingValid);
+
+        board = new ChessBoard();
+        king = new King(board, ChessPiece.Color.WHITE);
+        bKing = new King(board, ChessPiece.Color.BLACK);
+        bQueen = new Queen(board, ChessPiece.Color.BLACK);
+        Pawn bPawn = new Pawn(board, ChessPiece.Color.BLACK);
+
+        board.placePiece(king, "f1");
+        board.placePiece(bKing, "f10");
+        board.placePiece(bQueen, "f2");
+        board.placePiece(bPawn, "g3");
+
+        kingValid = king.legalMoves(true, false).getListOfMoves();
+        assertEquals(validMoves, kingValid);
+
+        board = new ChessBoard();
+        king = new King(board, ChessPiece.Color.WHITE);
+        bKing = new King(board, ChessPiece.Color.BLACK);
+        bQueen = new Queen(board, ChessPiece.Color.BLACK);
+        Knight bKnight = new Knight(board, ChessPiece.Color.BLACK);
+
+        board.placePiece(king, "f1");
+        board.placePiece(bKing, "f10");
+        board.placePiece(bQueen, "f2");
+        board.placePiece(bKnight, "g4");
+
+        kingValid = king.legalMoves(true, false).getListOfMoves();
+        assertEquals(validMoves, kingValid);
+
+        board = new ChessBoard();
+        king = new King(board, ChessPiece.Color.WHITE);
+        bKing = new King(board, ChessPiece.Color.BLACK);
+        bQueen = new Queen(board, ChessPiece.Color.BLACK);
+        Wizard bWizard = new Wizard(board, ChessPiece.Color.BLACK);
+
+        board.placePiece(king, "f1");
+        board.placePiece(bKing, "f10");
+        board.placePiece(bQueen, "f2");
+        board.placePiece(bWizard, "g5");
+
+        kingValid = king.legalMoves(true, false).getListOfMoves();
+        assertEquals(validMoves, kingValid);
+
+        board = new ChessBoard();
+        king = new King(board, ChessPiece.Color.WHITE);
+        bKing = new King(board, ChessPiece.Color.BLACK);
+        bQueen = new Queen(board, ChessPiece.Color.BLACK);
+        Champion bChamp = new Champion(board, ChessPiece.Color.BLACK);
+
+        board.placePiece(king, "f1");
+        board.placePiece(bKing, "f10");
+        board.placePiece(bQueen, "f2");
+        board.placePiece(bChamp, "h4");
+
+        kingValid = king.legalMoves(true, false).getListOfMoves();
+        assertEquals(validMoves, kingValid);
+
+        board = new ChessBoard();
+        king = new King(board, ChessPiece.Color.WHITE);
+        bKing = new King(board, ChessPiece.Color.BLACK);
+        bQueen = new Queen(board, ChessPiece.Color.BLACK);
+        Queen bQueen2 = new Queen(board, ChessPiece.Color.BLACK);
+
+        board.placePiece(king, "f1");
+        board.placePiece(bKing, "f10");
+        board.placePiece(bQueen, "f2");
+        board.placePiece(bQueen2, "h4");
+
+        kingValid = king.legalMoves(true, false).getListOfMoves();
         assertEquals(validMoves, kingValid);
     }
 

--- a/server/src/test/java/com/omegaChess/TestKnight.java
+++ b/server/src/test/java/com/omegaChess/TestKnight.java
@@ -84,7 +84,7 @@ class TestKnight {
         validMoves.add("e3");
 
         // get kings valid moves
-        LegalMoves moves = knight.legalMoves(true);
+        LegalMoves moves = knight.legalMoves(true, false);
         ArrayList<String> knightValid = moves.getListOfMoves();
 
         // Sort in case they come in a different order
@@ -107,7 +107,7 @@ class TestKnight {
         validMoves.add("e3");
 
         // get kings valid moves
-        moves = knight.legalMoves(true);
+        moves = knight.legalMoves(true, false);
         knightValid = moves.getListOfMoves();
 
         // Sort in case they come in a different order

--- a/server/src/test/java/com/omegaChess/TestPawn.java
+++ b/server/src/test/java/com/omegaChess/TestPawn.java
@@ -82,7 +82,7 @@ class TestPawn {
         validMoves.add("c4");
         validMoves.add("c5");
 
-        LegalMoves moves = pawn.legalMoves(true);
+        LegalMoves moves = pawn.legalMoves(true, false);
         ArrayList<String> pawnValid = moves.getListOfMoves();
         Collections.sort(validMoves);
         Collections.sort(pawnValid);
@@ -95,7 +95,7 @@ class TestPawn {
         validMoves.clear();
         validMoves.add("c3");
 
-        moves = pawn.legalMoves(true);
+        moves = pawn.legalMoves(true, false);
         pawnValid = moves.getListOfMoves();
         Collections.sort(validMoves);
         Collections.sort(pawnValid);
@@ -107,7 +107,7 @@ class TestPawn {
 
         validMoves.clear();
 
-        moves = pawn.legalMoves(true);
+        moves = pawn.legalMoves(true, false);
         pawnValid = moves.getListOfMoves();
         Collections.sort(validMoves);
         Collections.sort(pawnValid);
@@ -131,7 +131,7 @@ class TestPawn {
         validMoves.add("c4");
         validMoves.add("c5");
 
-        moves = pawn.legalMoves(true);
+        moves = pawn.legalMoves(true, false);
         pawnValid = moves.getListOfMoves();
         Collections.sort(validMoves);
         Collections.sort(pawnValid);
@@ -155,7 +155,7 @@ class TestPawn {
         validMoves.add("c6");
         validMoves.add("d8");
 
-        moves = pawn.legalMoves(true);
+        moves = pawn.legalMoves(true, false);
         pawnValid = moves.getListOfMoves();
         Collections.sort(validMoves);
         Collections.sort(pawnValid);
@@ -175,7 +175,7 @@ class TestPawn {
         validMoves.clear();
         validMoves.add("c6");
 
-        moves = pawn.legalMoves(true);
+        moves = pawn.legalMoves(true, false);
         pawnValid = moves.getListOfMoves();
         Collections.sort(validMoves);
         Collections.sort(pawnValid);
@@ -197,7 +197,7 @@ class TestPawn {
 
         validMoves.clear();
 
-        moves = pawn.legalMoves(true);
+        moves = pawn.legalMoves(true, false);
         pawnValid = moves.getListOfMoves();
         Collections.sort(validMoves);
         Collections.sort(pawnValid);
@@ -221,7 +221,7 @@ class TestPawn {
         validMoves.add("c5");
         validMoves.add("b5");
 
-        moves = pawn.legalMoves(true);
+        moves = pawn.legalMoves(true, false);
         pawnValid = moves.getListOfMoves();
         Collections.sort(validMoves);
         Collections.sort(pawnValid);
@@ -246,7 +246,7 @@ class TestPawn {
         validMoves.clear();
         validMoves.add("d5");
 
-        moves = pawn.legalMoves(true);
+        moves = pawn.legalMoves(true, false);
         pawnValid = moves.getListOfMoves();
         Collections.sort(validMoves);
         Collections.sort(pawnValid);
@@ -270,7 +270,7 @@ class TestPawn {
 
         validMoves.clear();
 
-        moves = pawn.legalMoves(true);
+        moves = pawn.legalMoves(true, false);
         pawnValid = moves.getListOfMoves();
         Collections.sort(validMoves);
         Collections.sort(pawnValid);
@@ -297,7 +297,7 @@ class TestPawn {
         validMoves.add("d5");
         validMoves.add("b5");
 
-        moves = pawn.legalMoves(true);
+        moves = pawn.legalMoves(true, false);
         pawnValid = moves.getListOfMoves();
         Collections.sort(validMoves);
         Collections.sort(pawnValid);
@@ -328,7 +328,7 @@ class TestPawn {
         validMoves.add("d3");
         validMoves.add("c3");
 
-        moves = pawn.legalMoves(true);
+        moves = pawn.legalMoves(true, false);
         pawnValid = moves.getListOfMoves();
         Collections.sort(validMoves);
         Collections.sort(pawnValid);
@@ -359,7 +359,7 @@ class TestPawn {
         validMoves.add("b3");
         validMoves.add("c3");
 
-        moves = pawn.legalMoves(true);
+        moves = pawn.legalMoves(true, false);
         pawnValid = moves.getListOfMoves();
         Collections.sort(validMoves);
         Collections.sort(pawnValid);

--- a/server/src/test/java/com/omegaChess/TestQueen.java
+++ b/server/src/test/java/com/omegaChess/TestQueen.java
@@ -113,7 +113,7 @@ class TestQueen {
         validMoves.add("b5");
         validMoves.add("a5");
 
-        LegalMoves moves = queen.legalMoves(true);
+        LegalMoves moves = queen.legalMoves(true, false);
         ArrayList<String> queenValid = moves.getListOfMoves();
         Collections.sort(validMoves);
         Collections.sort(queenValid);

--- a/server/src/test/java/com/omegaChess/TestRook.java
+++ b/server/src/test/java/com/omegaChess/TestRook.java
@@ -92,7 +92,7 @@ class TestRook {
         validMoves.add("i2");
         validMoves.add("j2");
 
-        LegalMoves moves = rook.legalMoves(true);
+        LegalMoves moves = rook.legalMoves(true, false);
         ArrayList<String> rookValid = moves.getListOfMoves();
         Collections.sort(validMoves);
         Collections.sort(rookValid);
@@ -123,7 +123,7 @@ class TestRook {
         validMoves.add("i2");
         validMoves.add("j2");
 
-        moves = rook.legalMoves(true);
+        moves = rook.legalMoves(true, false);
         rookValid = moves.getListOfMoves();
         Collections.sort(validMoves);
         Collections.sort(rookValid);
@@ -154,7 +154,7 @@ class TestRook {
         validMoves.add("f3");
         validMoves.add("f4");
 
-        moves = rook.legalMoves(true);
+        moves = rook.legalMoves(true, false);
         rookValid = moves.getListOfMoves();
         Collections.sort(validMoves);
         Collections.sort(rookValid);

--- a/server/src/test/java/com/omegaChess/TestWizard.java
+++ b/server/src/test/java/com/omegaChess/TestWizard.java
@@ -39,7 +39,7 @@ class TestWizard{
         expectedMoves.add("f6"); expectedMoves.add("f8"); expectedMoves.add("h6"); expectedMoves.add("j6");
         expectedMoves.add("h4"); expectedMoves.add("h2"); expectedMoves.add("f4"); expectedMoves.add("d4");
         expectedMoves.add("h8"); expectedMoves.add("j4"); expectedMoves.add("f2"); expectedMoves.add("d6");
-        LegalMoves moves = wiz.legalMoves(true);
+        LegalMoves moves = wiz.legalMoves(true, false);
         ArrayList<String> actualMoves = moves.getListOfMoves();
         assertEquals(expectedMoves, actualMoves, "Expected moves not provided");
     }


### PR DESCRIPTION
King could capture a piece putting it in check even if that piece was protected by another. Fixed by adding another parameter to ChessPiece legalMoves called protectedPieceChecking that is only called as true the king's willKingBeInCheck method. Each piece (other than pawn and king) has a additional conditions to add a space to the legal moves even if it's occupied by a friendly piece only when the protectedPieceChecking parameter is true.
Also added tests to TestKing for this condition.

closes #353 