### PR TITLE
End match & result screen

### DIFF
--- a/core/src/com/csc14/runtimeterrors/game/BoardAssets/GameBoard.java
+++ b/core/src/com/csc14/runtimeterrors/game/BoardAssets/GameBoard.java
@@ -3,6 +3,7 @@ package com.csc14.runtimeterrors.game.BoardAssets;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.scenes.scene2d.InputEvent;
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
+import com.csc14.runtimeterrors.game.MatchScreen;
 import com.csc14.runtimeterrors.game.OCMessage;
 import com.csc14.runtimeterrors.game.OmegaChess;
 
@@ -319,6 +320,9 @@ public class GameBoard {
                                 for (String position : highlightedSquares) {
                                     getSquare(position).unHighlight();
                                 }
+
+                                MatchScreen m = (MatchScreen) parent.getScreen();
+                                m.setJustFinishedTurnTrue();
                             }
                             // if second click is on a non-highlighted square, reset first click and unhighlight squares
                             else if (clickedPiece != null && !square.isHighlighted()) {

--- a/core/src/com/csc14/runtimeterrors/game/MatchScreen.java
+++ b/core/src/com/csc14/runtimeterrors/game/MatchScreen.java
@@ -106,12 +106,17 @@ public class MatchScreen implements Screen {
         forfeit.addListener(new ClickListener() {
             @Override
             public void clicked(InputEvent even, float x, float y) {
-                if (parent.getUser().equalsIgnoreCase(board.getWhitePlayer())) {
-                    parent.getClient().endMatch(board.getMatchID(), parent.getUser(), board.getBlackPlayer());
-                }else{
-                    parent.getClient().endMatch(board.getMatchID(), parent.getUser(), board.getWhitePlayer());
+                int result = JOptionPane.showConfirmDialog(null, "Are you sure you want to forfeit?",
+                        "Forfeit?", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
+
+                if (result == JOptionPane.YES_OPTION) {
+                    if (parent.getUser().equalsIgnoreCase(board.getWhitePlayer())) {
+                        parent.getClient().endMatch(board.getMatchID(), parent.getUser(), board.getBlackPlayer());
+                    } else {
+                        parent.getClient().endMatch(board.getMatchID(), parent.getUser(), board.getWhitePlayer());
+                    }
+                    parent.changeScreen(OmegaChess.SCREEN.LOBBY);
                 }
-                parent.changeScreen(OmegaChess.SCREEN.LOBBY);
         }
         });
 
@@ -146,6 +151,9 @@ public class MatchScreen implements Screen {
 
             currentTurn.setText("Current Turn: " + board.getTurn());
 
+            //check for forfeit
+            checkForfeit();
+
             // just switched turns, check checkmate
             if (parent.getUser().equals(board.getTurn()) || justFinishedTurn) {
                 checkCheckmate(justFinishedTurn);
@@ -173,6 +181,21 @@ public class MatchScreen implements Screen {
                 }
                 JOptionPane.showMessageDialog(null, message, title, JOptionPane.INFORMATION_MESSAGE);
                 parent.getClient().endMatch(board.getMatchID(), receivedMessage.get("winner"), receivedMessage.get("loser"));
+                parent.changeScreen(OmegaChess.SCREEN.LOBBY);
+            }
+        }
+    }
+
+    private void checkForfeit() {
+        OCMessage receivedMessage = parent.getClient().getForfeit(board.getMatchID());
+
+        if (receivedMessage.get("success").equals("true")) {
+            if (receivedMessage.get("forfeit").equals("true")) {
+                String title = "Forfeit!";
+                String message = board.getTurn() + " has forfeit the match!";
+
+                JOptionPane.showMessageDialog(null, message, title, JOptionPane.INFORMATION_MESSAGE);
+                parent.getClient().endMatch(board.getMatchID(), parent.getUser(), board.getTurn());
                 parent.changeScreen(OmegaChess.SCREEN.LOBBY);
             }
         }

--- a/core/src/com/csc14/runtimeterrors/game/OCClient.java
+++ b/core/src/com/csc14/runtimeterrors/game/OCClient.java
@@ -345,11 +345,24 @@ public class OCClient {
         return receivedMessage;
     }
 
-    // End match
+    // get game records
     public OCMessage getGameRecords(String nickname){
         OCMessage message = new OCMessage(), receivedMessage;
         message.put("process", "get game records");
         message.put("user", nickname);
+
+        receivedMessage = sendRequestAndReceiveMessage(message);
+
+        printResult(receivedMessage);
+
+        return receivedMessage;
+    }
+
+    // request checkmate check
+    public OCMessage getCheckmate(int matchID) {
+        OCMessage message = new OCMessage(), receivedMessage;
+        message.put("process", "checkmate check");
+        message.put("ID", String.valueOf(matchID));
 
         receivedMessage = sendRequestAndReceiveMessage(message);
 

--- a/core/src/com/csc14/runtimeterrors/game/OCClient.java
+++ b/core/src/com/csc14/runtimeterrors/game/OCClient.java
@@ -370,4 +370,17 @@ public class OCClient {
 
         return receivedMessage;
     }
+
+    // request forfeit check
+    public OCMessage getForfeit(int matchID) {
+        OCMessage message = new OCMessage(), receivedMessage;
+        message.put("process", "forfeit check");
+        message.put("ID", String.valueOf(matchID));
+
+        receivedMessage = sendRequestAndReceiveMessage(message);
+
+        printResult(receivedMessage);
+
+        return receivedMessage;
+    }
 }

--- a/protocol.md
+++ b/protocol.md
@@ -269,3 +269,73 @@ Return Message Success:
 Return Message Failure:
 * "success": "false"
 * "reason": "no records for that user"
+
+## End Match
+- This request marks the match as ready for completion if it is the first time a match calls end and then ends the match and creates the game record on the second.
+
+ Message Template:
+ * "process": "end match"
+ * "ID": "match ID"
+ * "winner": "winning player"
+ * "loser": "losing player"
+ 
+ Return Message Template 1:
+ * "success": "true"
+ 
+ Return Message Template 2:
+ * "success": "true"
+ * "ID": "archive ID"
+ 
+ Return Message Template 3:
+ * "success": "false"
+ * "reason": "There are no matches available"
+ 
+ Return Message Template 4:
+ * "success": "false"
+ * "reason": "there is no match with ID #"
+ 
+ ## Check Checkmate
+ - This request checks if the current turn player is in checkmate.
+ 
+ Message Template:
+ * "process": "checkmate check"
+ * "ID": "match ID"
+ 
+ Return Message Template 1:
+ * "success": "true"
+ * "checkmate": "false"
+ 
+ Return Message Template 2:
+ * "success": "true"
+ * "checkmate": "false"
+ * "loser": "losing player"
+ * "winner": "winning player"
+ 
+ Return Message Template 3:
+ * "success": "false"
+ * "reason": "There are no matches available"
+ 
+ Return Message Template 4:
+ * "success": "false"
+ * "reason": "there is no match with ID #"
+ 
+ ## Check Forfeit
+ - This request checks if the other player has forfeit the match.
+ 
+ Message Template:
+ * "process": "forfeit check"
+ * "ID": "match ID"
+ 
+ Return Message Template 1:
+ * "success": "true"
+ * "checkmate": "true/false"
+ 
+ Return Message Template 2:
+ * "success": "false"
+ * "reason": "There are no matches available"
+ 
+ Return Message Template 3:
+ * "success": "false"
+ * "reason": "there is no match with ID #"
+ 
+ 

--- a/server/src/main/java/com/omegaChess/server/Match.java
+++ b/server/src/main/java/com/omegaChess/server/Match.java
@@ -20,6 +20,7 @@ public class Match {
     private String profile1, profile2;
     private static int matchCount = 0;
     private int matchID;
+    private boolean acknowledgeEnd = false;
 
     // Profile 1 should be the profile that sent an invite
     public Match(String profile1, String profile2){
@@ -46,10 +47,10 @@ public class Match {
         boolean check = true, noBlock = true;
         switch (board.getTurn().getCurrentTurnColor()){
             case WHITE:
-                currentPieces = board.get_black_pieces();
+                currentPieces = board.get_white_pieces();
                 break;
             case BLACK:
-                currentPieces = board.get_white_pieces();
+                currentPieces = board.get_black_pieces();
                 break;
         }
 
@@ -96,6 +97,14 @@ public class Match {
     public String getProfile1() { return profile1; }
 
     public String getProfile2() { return profile2; }
+
+    public void setAcknowledgeEnd(boolean acknowledgeEnd) {
+        this.acknowledgeEnd = acknowledgeEnd;
+    }
+
+    public boolean isAcknowledgeEnd() {
+        return acknowledgeEnd;
+    }
 
     public void save(String saveLocation) {
         createDirectoryIfNonExistent(saveLocation);

--- a/server/src/main/java/com/omegaChess/server/OCProtocol.java
+++ b/server/src/main/java/com/omegaChess/server/OCProtocol.java
@@ -82,6 +82,9 @@ public class OCProtocol {
                 case "checkmate check":
                     toReturn = checkCheckmate(receivedMessage);
                     break;
+                case "forfeit check":
+                    toReturn = checkForfeit(receivedMessage);
+                    break;
                 default:
                     message = new OCMessage();
                     message.put("success", "false");
@@ -833,6 +836,39 @@ public class OCProtocol {
         }
         else {
             message.put("checkmate", "false");
+        }
+
+        return message.toString();
+    }
+
+    private String checkForfeit(OCMessage receivedMessage) {
+        int ID = Integer.valueOf(receivedMessage.get("ID"));
+        message = new OCMessage();
+
+        Match match = null;
+        if (serverData.getMatches().size() == 0){
+            message.put("success", "false");
+            message.put("reason", "There are no matches available");
+            return message.toString();
+        }
+        for (Match m : serverData.getMatches()){
+            if (m.getMatchID() == ID) {
+                message.put("success", "true");
+                match = m;
+                break;
+            }
+        }
+        if (match == null){
+            message.put("success", "false");
+            message.put("reason", "there is no match with ID " + ID);
+            return message.toString();
+        }
+
+        if (match.isAcknowledgeEnd()) {
+            message.put("forfeit", "true");
+        }
+        else {
+            message.put("forfeit", "false");
         }
 
         return message.toString();

--- a/server/src/main/java/com/omegaChess/server/OCProtocol.java
+++ b/server/src/main/java/com/omegaChess/server/OCProtocol.java
@@ -79,6 +79,9 @@ public class OCProtocol {
                 case "get game records":
                     toReturn = getGameRecords(receivedMessage);
                     break;
+                case "checkmate check":
+                    toReturn = checkCheckmate(receivedMessage);
+                    break;
                 default:
                     message = new OCMessage();
                     message.put("success", "false");
@@ -679,33 +682,38 @@ public class OCProtocol {
         return message.toString();
     }
 
-    public String endMatch(OCMessage receivedMessage){
+    public String endMatch(OCMessage receivedMessage) {
         int ID = Integer.valueOf(receivedMessage.get("ID")), moves = 0;
         String loser = receivedMessage.get("loser"), winner = receivedMessage.get("winner");
         message = new OCMessage();
 
         Match end = null;
-        if (serverData.getMatches().size() == 0){
+        if (serverData.getMatches().size() == 0) {
             message.put("success", "false");
             message.put("reason", "There are no matches available");
             return message.toString();
         }
-        for (Match match : serverData.getMatches()){
+        for (Match match : serverData.getMatches()) {
             if (match.getMatchID() == ID) {
                 message.put("success", "true");
                 end = match;
                 break;
             }
         }
-        if (end == null){
+        if (end == null) {
             message.put("success", "false");
             message.put("reason", "there is no match with ID " + ID);
             return message.toString();
         }
-        moves = end.getBoard().getMoves().size();
-        end.endMatch(loser, winner, moves);
-        serverData.removeMatch(end);
-        message.put("ID", String.valueOf(serverData.getArchive().size()));
+        if (end.isAcknowledgeEnd()) {
+            moves = end.getBoard().getMoves().size();
+            serverData.addToArchive(end.endMatch(loser, winner, moves));
+            serverData.removeMatch(end);
+            message.put("ID", String.valueOf(serverData.getArchive().size()));
+        }
+        else {
+            end.setAcknowledgeEnd(true);
+        }
 
         return message.toString();
     }
@@ -740,6 +748,7 @@ public class OCProtocol {
 
     private String getGameRecords(OCMessage receivedMessage) {
         String user = receivedMessage.get("user");
+        message = new OCMessage();
 
         if (!serverData.profileExists(user)){
             // target user doesn't exist
@@ -781,6 +790,50 @@ public class OCProtocol {
             }
         }
         message.put("number", "" + countForUser);
+
+        return message.toString();
+    }
+
+    private String checkCheckmate(OCMessage receivedMessage) {
+        int ID = Integer.valueOf(receivedMessage.get("ID"));
+        message = new OCMessage();
+
+        Match match = null;
+        if (serverData.getMatches().size() == 0){
+            message.put("success", "false");
+            message.put("reason", "There are no matches available");
+            return message.toString();
+        }
+        for (Match m : serverData.getMatches()){
+            if (m.getMatchID() == ID) {
+                message.put("success", "true");
+                match = m;
+                break;
+            }
+        }
+        if (match == null){
+            message.put("success", "false");
+            message.put("reason", "there is no match with ID " + ID);
+            return message.toString();
+        }
+        String p1 = match.getProfile1();
+        String p2 = match.getProfile2();
+        boolean inCheckmate = match.checkCheckmate();
+
+        if (inCheckmate) {
+            message.put("checkmate", "true");
+            if (p1.equals(match.getBoard().getTurn().getCurrentTurnPlayer())) {
+                message.put("loser", p1);
+                message.put("winner", p2);
+            }
+            else {
+                message.put("loser", p2);
+                message.put("winner", p1);
+            }
+        }
+        else {
+            message.put("checkmate", "false");
+        }
 
         return message.toString();
     }

--- a/server/src/test/java/com/omegaChess/TestMatch.java
+++ b/server/src/test/java/com/omegaChess/TestMatch.java
@@ -75,9 +75,10 @@ public class TestMatch {
         board.initializeInvalidSpaces();
 
         match = new Match(p1.getNickname(), p2.getNickname());
-        TurnTracker turn = new TurnTracker(p1.getNickname(), p2.getNickname());
-        match.getBoard().setTurn(turn);
         match.setBoard(board);
+        TurnTracker turn = new TurnTracker(p1.getNickname(), p2.getNickname());
+        turn.switchTurn();
+        match.getBoard().setTurn(turn);
 
         assertTrue(match.checkCheckmate(), "Black should be checkmate.");
 


### PR DESCRIPTION
Result Screen is now just a popup indicating the opponent forfeit or if there is checkmate.

I automated the refresh screen functionality using the render method. In the new refresh method is the same functionality as the button but with the following additions/changes:
1. Only executes if the current turn is not the user
2. After the refresh, checks to see if the other player has forfeit
         - Checks a new match variable indicating match end
3. After the forfeit check, checks if the current turn player is in check
         - Occurs on the last cycle of refresh when it becomes a players turn and the first refresh cycle after finishing a players turn.

To sync up the clients when ending the match there is a new boolean variable in the match screen to mark that one player has acknowledge the games end (forfeit or checkmate). The first client to send the end game request sets the variable as true and the second client to send the request creates the game record and ends the game.

closes #104 
closes #240
closes #85