### PR TITLE
Added info in the invite accepted notification

### DIFF
--- a/server/src/main/java/com/omegaChess/server/OCProtocol.java
+++ b/server/src/main/java/com/omegaChess/server/OCProtocol.java
@@ -484,7 +484,7 @@ public class OCProtocol {
                         int matchID = match.getMatchID();
                         serverData.addMatch(match);
                         mail.addNotification(Notification.NotificationType.ACCEPTED_INVITE,
-                                invitee + " accepted your invite request.");
+                                invitee + " accepted your invite request. Go to the Resume Game screen to enter the match.");
                         message.put("success", "true");
                         message.put("matchID", Integer.toString(matchID));
                         return message.toString();


### PR DESCRIPTION
The message saying someone accepted your invite didn't tell you how to enter the game. Added a bit to the message telling the player to go to the resume screen to enter the created match.